### PR TITLE
Terminate <input> elements in Maud example

### DIFF
--- a/examples/maudapp/src/components/todo.rs
+++ b/examples/maudapp/src/components/todo.rs
@@ -16,12 +16,12 @@ impl Renderable for TodoList {
             ul id="todo-ul" {
                 @for item in &self.items {
                     li class={ "todo-item " (item.complete) } {
-                        input type="checkbox" checked?[item.complete]
+                        input type="checkbox" checked?[item.complete] /
                         (item.label)
                     }
                 }
             }
-            input id="message" type="text"
+            input id="message" type="text" /
             button { "Add" }
         }).into_string()
     }


### PR DESCRIPTION
Without a trailing slash to terminate the `<input>`, Maud would treat whatever comes afterward as a child of the element.